### PR TITLE
Keyguard: Forward port lockscreen quick unlock (1/2)

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5501,6 +5501,18 @@ public final class Settings {
 
         /**
          * Disable power menu on secure lock screens
+         * Whether to use the custom quick unlock screen control
+         * @hide
+         */
+        public static final String LOCKSCREEN_QUICK_UNLOCK_CONTROL =
+                "lockscreen_quick_unlock_control";
+
+        /**
+         * Keys we no longer back up under the current schema, but want to continue to
+         * process when restoring historical backup datasets.
+         *
+         * All settings in {@link LEGACY_RESTORE_SETTINGS} array *must* have a non-null validator,
+         * otherwise they won't be restored.
          *
          * @hide
          */

--- a/core/java/com/android/internal/widget/LockPatternUtils.java
+++ b/core/java/com/android/internal/widget/LockPatternUtils.java
@@ -402,7 +402,6 @@ public class LockPatternUtils {
     @NonNull
     public VerifyCredentialResponse verifyCredential(@NonNull LockscreenCredential credential,
             int userId, @VerifyFlag int flags) {
-        throwIfCalledOnMainThread();
         try {
             final VerifyCredentialResponse response = getLockSettings().verifyCredential(
                     credential, userId, flags);
@@ -460,7 +459,6 @@ public class LockPatternUtils {
     public boolean checkCredential(@NonNull LockscreenCredential credential, int userId,
             @Nullable CheckCredentialProgressCallback progressCallback)
             throws RequestThrottledException {
-        throwIfCalledOnMainThread();
         try {
             VerifyCredentialResponse response = getLockSettings().checkCredential(
                     credential, userId, wrapCallback(progressCallback));
@@ -494,7 +492,6 @@ public class LockPatternUtils {
     @NonNull
     public VerifyCredentialResponse verifyTiedProfileChallenge(
             @NonNull LockscreenCredential credential, int userId, @VerifyFlag int flags) {
-        throwIfCalledOnMainThread();
         try {
             final VerifyCredentialResponse response = getLockSettings()
                     .verifyTiedProfileChallenge(credential, userId, flags);
@@ -1277,12 +1274,6 @@ public class LockPatternUtils {
         if (isDeviceEncryptionEnabled()){
             Settings.Global.putInt(mContext.getContentResolver(),
                Settings.Global.REQUIRE_PASSWORD_TO_DECRYPT, required ? 1 : 0);
-        }
-    }
-
-    private void throwIfCalledOnMainThread() {
-        if (Looper.getMainLooper().isCurrentThread()) {
-            throw new IllegalStateException("should not be called from the main thread.");
         }
     }
 

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPasswordViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPasswordViewController.java
@@ -16,9 +16,12 @@
 
 package com.android.keyguard;
 
+import static com.android.keyguard.KeyguardAbsKeyInputView.MINIMUM_PASSWORD_LENGTH_BEFORE_REPORT;
+
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.os.UserHandle;
+import android.provider.Settings;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -37,7 +40,9 @@ import android.widget.ImageView;
 import android.widget.TextView.OnEditorActionListener;
 
 import com.android.internal.util.LatencyTracker;
+import com.android.internal.widget.LockscreenCredential;
 import com.android.internal.widget.LockPatternUtils;
+import com.android.internal.widget.LockPatternUtils.RequestThrottledException;
 import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.settingslib.Utils;
 import com.android.systemui.R;
@@ -58,6 +63,12 @@ public class KeyguardPasswordViewController
     private final boolean mShowImeAtScreenOn;
     private EditText mPasswordEntry;
     private ImageView mSwitchImeButton;
+
+    private final boolean quickUnlock = (Settings.System.getIntForUser(getContext().getContentResolver(),
+            Settings.System.LOCKSCREEN_QUICK_UNLOCK_CONTROL, 0, UserHandle.USER_CURRENT) == 1);
+    private final int userId = KeyguardUpdateMonitor.getCurrentUser();
+
+    private LockPatternUtils mLockPatternUtils;
 
     private final OnEditorActionListener mOnEditorActionListener = (v, actionId, event) -> {
         // Check if this was the result of hitting the enter key
@@ -89,6 +100,15 @@ public class KeyguardPasswordViewController
         public void afterTextChanged(Editable s) {
             if (!TextUtils.isEmpty(s)) {
                 onUserInput();
+                if (quickUnlock) {
+                    LockscreenCredential entry = mView.getEnteredCredential();
+                    if (entry.size() > MINIMUM_PASSWORD_LENGTH_BEFORE_REPORT
+                            && kpvCheckPassword(entry)) {
+                        mKeyguardSecurityCallback.reportUnlockAttempt(userId, true, 0);
+                        mKeyguardSecurityCallback.dismiss(true, userId);
+                        mView.resetPasswordText(true, true);
+                    }
+                }
             }
         }
     };
@@ -126,6 +146,7 @@ public class KeyguardPasswordViewController
         mShowImeAtScreenOn = resources.getBoolean(R.bool.kg_show_ime_at_screen_on);
         mPasswordEntry = mView.findViewById(mView.getPasswordTextViewId());
         mSwitchImeButton = mView.findViewById(R.id.switch_ime_button);
+        mLockPatternUtils = lockPatternUtils;
     }
 
     @Override
@@ -308,5 +329,13 @@ public class KeyguardPasswordViewController
                 // imm.getEnabledInputMethodSubtypeList(null, false) will return the current IME's
                 //enabled input method subtype (The current IME should be LatinIME.)
                 || imm.getEnabledInputMethodSubtypeList(null, false).size() > 1;
+    }
+
+    private boolean kpvCheckPassword(LockscreenCredential entry) {
+        try {
+            return mLockPatternUtils.checkCredential(entry, userId, null);
+        } catch (RequestThrottledException ex) {
+            return false;
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPinViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPinViewController.java
@@ -15,11 +15,15 @@
  */
 
 package com.android.keyguard;
-
+import static com.android.keyguard.KeyguardAbsKeyInputView.MINIMUM_PASSWORD_LENGTH_BEFORE_REPORT;
+import android.os.UserHandle;
+import android.provider.Settings;
 import android.view.View;
-
 import com.android.internal.util.LatencyTracker;
 import com.android.internal.widget.LockPatternUtils;
+import com.android.internal.widget.LockPatternUtils.RequestThrottledException;
+import com.android.internal.widget.LockscreenCredential;
+import com.android.keyguard.PasswordTextView.QuickUnlockListener;
 import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.systemui.R;
 import com.android.systemui.classifier.FalsingCollector;
@@ -31,6 +35,9 @@ public class KeyguardPinViewController
     private final DevicePostureController mPostureController;
     private final DevicePostureController.Callback mPostureCallback = posture ->
             mView.onDevicePostureChanged(posture);
+
+    private int userId = KeyguardUpdateMonitor.getCurrentUser();
+    private LockPatternUtils mLockPatternUtils;
 
     protected KeyguardPinViewController(KeyguardPINView view,
             KeyguardUpdateMonitor keyguardUpdateMonitor,
@@ -46,6 +53,8 @@ public class KeyguardPinViewController
                 emergencyButtonController, falsingCollector);
         mKeyguardUpdateMonitor = keyguardUpdateMonitor;
         mPostureController = postureController;
+        mLockPatternUtils = lockPatternUtils;
+        
     }
 
     @Override
@@ -60,6 +69,19 @@ public class KeyguardPinViewController
             });
         }
 
+
+        boolean quickUnlock = (Settings.System.getIntForUser(getContext().getContentResolver(),
+        Settings.System.LOCKSCREEN_QUICK_UNLOCK_CONTROL, 0, UserHandle.USER_CURRENT) == 1);
+
+        if (quickUnlock) {
+            mPasswordEntry.setQuickUnlockListener(new QuickUnlockListener() {
+        public void onValidateQuickUnlock(String password) {
+            validateQuickUnlock(password);
+        }
+    });
+        } else {
+    mPasswordEntry.setQuickUnlockListener(null);
+}
         mPostureController.addCallback(mPostureCallback);
     }
 
@@ -85,5 +107,26 @@ public class KeyguardPinViewController
     public boolean startDisappearAnimation(Runnable finishRunnable) {
         return mView.startDisappearAnimation(
                 mKeyguardUpdateMonitor.needsSlowUnlockTransition(), finishRunnable);
+    }
+
+    private void validateQuickUnlock(String password) {
+        if (password != null) {
+            if (password.length() > MINIMUM_PASSWORD_LENGTH_BEFORE_REPORT
+                    && kpvCheckPassword(password)) {
+                mPasswordEntry.setEnabled(false);
+                getKeyguardSecurityCallback().reportUnlockAttempt(userId, true, 0);
+                getKeyguardSecurityCallback().dismiss(true, userId);
+                mView.resetPasswordText(true, true);
+            }
+        }
+    }
+
+    private boolean kpvCheckPassword(String password) {
+        try {
+            return mLockPatternUtils.checkCredential(
+                    LockscreenCredential.createPinOrNone(password), userId, null);
+        } catch (RequestThrottledException ex) {
+            return false;
+        }
     }
 }

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSimPinViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSimPinViewController.java
@@ -86,6 +86,7 @@ public class KeyguardSimPinViewController
         mKeyguardUpdateMonitor = keyguardUpdateMonitor;
         mTelephonyManager = telephonyManager;
         mSimImageView = mView.findViewById(R.id.keyguard_sim);
+        mPasswordEntry.setQuickUnlockListener(null);
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSimPukViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSimPukViewController.java
@@ -92,6 +92,7 @@ public class KeyguardSimPukViewController
         mKeyguardUpdateMonitor = keyguardUpdateMonitor;
         mTelephonyManager = telephonyManager;
         mSimImageView = mView.findViewById(R.id.keyguard_sim);
+        mPasswordEntry.setQuickUnlockListener(null);
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/keyguard/PasswordTextView.java
+++ b/packages/SystemUI/src/com/android/keyguard/PasswordTextView.java
@@ -102,9 +102,23 @@ public class PasswordTextView extends View {
     private Interpolator mFastOutSlowInInterpolator;
     private boolean mShowPassword;
     private UserActivityListener mUserActivityListener;
+    protected QuickUnlockListener mQuickUnlockListener;
 
     public interface UserActivityListener {
         void onUserActivity();
+    }
+
+    /* Quick unlock management for PIN view. */
+    public interface QuickUnlockListener {
+        /**
+         * Validate current password and prepare callback if verified.
+         * @param password The password string to be verified.
+         */
+        void onValidateQuickUnlock(String password);
+    }
+
+    public void setQuickUnlockListener(QuickUnlockListener listener) {
+        mQuickUnlockListener = listener;
     }
 
     public PasswordTextView(Context context) {
@@ -265,6 +279,10 @@ public class PasswordTextView extends View {
         }
         userActivity();
         sendAccessibilityEventTypeViewTextChanged(textbefore, textbefore.length(), 0, 1);
+
+        if (mQuickUnlockListener != null) {
+            mQuickUnlockListener.onValidateQuickUnlock(mText);
+        }
     }
 
     public void setUserActivityListener(UserActivityListener userActivitiListener) {


### PR DESCRIPTION
Aex Edits:
port to S

commit 142719299d1bea5db21d17b9cc7687efe553a1a3
Author: Veeti Paananen <veeti.paananen@rojekti.fi>
Date:   Tue Jun 9 12:44:59 2015 +0300

    Disable PIN entry after successful quick unlock

    Small polish: I still often press the enter button out of muscle memory
    when entering my PIN code, which leads to an "invalid PIN" message being
    shown for a tiny moment as the screen unlocks. Disable the entry view
    after a quick unlock to fix this.

    Change-Id: Icceb8311ed55564e9b1d92934cbca814a1cc4b29
    Signed-off-by: mydongistiny <jaysonedson@gmail.com>

commit 83278c5e9fde3d1dd6a4107d2483f5cd8fc450fa
Author: Matt Mower <mowerm@gmail.com>
Date:   Wed Dec 31 15:02:58 2014 -0600

    Keyguard: Forward port lockscreen quick unlock (1/2)

    * PasswordTextView QuickUnlock listener functions and method thanks to
      ParanoidAndroid project:
        Keyguard: Implement quick unlock feature [1/2]
        BigBrother1984 <carlosavignano@aospa.co>
        I0b3d92b91f72020d327a7f2f184c2fbc5519a5df

    mydongistiny: ported to oreo/android10
    Signed-off-by: mydongistiny <jaysonedson@gmail.com>

Signed-off-by: Matis Stocco <stoccomatis7@gmail.com>